### PR TITLE
fixed typo 'cititai' > 'civitai'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LoRA-for-Diffusers
 
-This repository provides the simplest tutorial code for AIGC researchers to use Lora in just a few lines. Using this handbook, you can easily play with any Lora model from active communities such as [Huggingface](https://huggingface.co/) and [cititai](https://civitai.com/).
+This repository provides the simplest tutorial code for AIGC researchers to use Lora in just a few lines. Using this handbook, you can easily play with any Lora model from active communities such as [Huggingface](https://huggingface.co/) and [civitai](https://civitai.com/).
 
 Now, we also support [ControlNet-for-Diffusers](https://github.com/haofanwang/ControlNet-for-Diffusers), [T2I-Adapter-for-Diffusers](https://github.com/haofanwang/T2I-Adapter-for-Diffusers).
 


### PR DESCRIPTION
Simple typo fix, I was confused if it wasn't referring to civitai 